### PR TITLE
refactor subscriber for concurrency

### DIFF
--- a/subscriber/app.py
+++ b/subscriber/app.py
@@ -10,9 +10,11 @@ from crawler.imports.types2 import MethodGet, Scheme, SchemeHttp, SchemeHttps, S
 from crawler.imports.messaging_types import GuestConfiguration, Message, FormatSpec
 from crawler.imports import types as kv, readwrite
 from poll_loop import Stream, Sink, PollLoop
-from typing import List, Tuple, cast
+from typing import List, Tuple, cast, Optional
 from html.parser import HTMLParser
 from urllib import parse
+from datetime import datetime
+from dataclasses import dataclass
 
 class MessagingGuest(exports.MessagingGuest):
     def configure(self) -> GuestConfiguration:
@@ -24,62 +26,82 @@ class MessagingGuest(exports.MessagingGuest):
         loop.run_until_complete(handle_async(messages))
 
 async def handle_async(messages: List[Message]):
-    client = None
-    for message in messages:
-        body = json.loads(message.data)
-        url: str = body["url"]
-        depth: int = body["depth"]
-            
-        if depth < MAX_DEPTH:
-            mime, body = await get(url)
+    print(f"{datetime.now()}: got {len(messages)} messages")
 
-            print(f"got {url}: mime: {mime} body length: {len(body)}")
-            
-            if mime.startswith("image/jpeg"):
-                print(f"found a jpeg from url {url}")
-                bucket = kv.open_bucket("images")
-                outgoing_value = kv.new_outgoing_value()
-                kv.outgoing_value_write_body_sync(outgoing_value, body)
-                readwrite.set(bucket, url, outgoing_value)
+    for result in asyncio.as_completed(map(maybe_get, messages)):
+        value = await result
+        
+        if value is not None:
+            value.crawl()
 
-            if depth + 1 < MAX_DEPTH and mime.startswith("text/html"):
-                urls = get_urls(str(body, "utf-8"), 'https://www.fermyon.com')
+@dataclass
+class Download:
+    depth: int
+    url: str
+    mime: str
+    body: bytes
+    
+    def crawl(self):
+        print(f"{datetime.now()}: got {self.url}: mime: {self.mime} body length: {len(self.body)}")
                 
-                print(f"{url}: found {len(urls)} urls")
+        if self.mime.startswith("image/"):
+            print(f"{datetime.now()}: found an image from url {self.url}")
             
-                for url in urls:
-                    bucket = kv.open_bucket("urls")
-                    try:
-                        incoming_value = readwrite.get(bucket, url)
-                        value = kv.incoming_value_consume_sync(incoming_value)
-                        # parse value of bytes to int
-                        value = int(value)
-                        outgoing_value = kv.new_outgoing_value()
-                        kv.outgoing_value_write_body_sync(outgoing_value, bytes(str(value + 1), "utf-8"))
-                        readwrite.set(bucket, url, outgoing_value)
-                    except Err as e:
-                        msg = kv.trace(e.value)
-                        print(f"error: {msg}")
-                    except ValueError as e:
-                        # if value is not an int, set it to 1
-                        outgoing_value = kv.new_outgoing_value()
-                        kv.outgoing_value_write_body_sync(outgoing_value, bytes("1", "utf-8"))
-                        readwrite.set(bucket, url, outgoing_value)
+            bucket = kv.open_bucket("images")
+            outgoing_value = kv.new_outgoing_value()
+            kv.outgoing_value_write_body_sync(outgoing_value, self.body)
+            readwrite.set(bucket, self.url, outgoing_value)
+                    
+        elif self.depth + 1 < MAX_DEPTH and self.mime.startswith("text/html"):
+            url_parsed = parse.urlparse(self.url)
+            urls = get_urls(str(self.body, "utf-8"), f"{url_parsed.scheme}://{url_parsed.netloc}/")
+                    
+            print(f"{datetime.now()}: {self.url}: found {len(urls)} urls")
+                
+            for url in urls:
+                bucket = kv.open_bucket("urls")
+                try:
+                    incoming_value = readwrite.get(bucket, url)
+                    value = kv.incoming_value_consume_sync(incoming_value)
+                    # parse value of bytes to int
+                    value = int(value)
+                    outgoing_value = kv.new_outgoing_value()
+                    kv.outgoing_value_write_body_sync(outgoing_value, bytes(str(value + 1), "utf-8"))
+                    readwrite.set(bucket, url, outgoing_value)
+                except Err as e:
+                    msg = kv.trace(e.value)
+                    print(f"error: {msg}")
+                except ValueError as e:
+                    # if value is not an int, set it to 1
+                    outgoing_value = kv.new_outgoing_value()
+                    kv.outgoing_value_write_body_sync(outgoing_value, bytes("1", "utf-8"))
+                    readwrite.set(bucket, url, outgoing_value)
+    
+                    client = messaging.connect(redis_address())
+                            
+                    producer.send(
+                        client,
+                        CHANNEL_NAME,
+                        [Message(
+                            bytes(json.dumps({"url": url, "depth": self.depth + 1}), "utf-8"),
+                            FormatSpec.RAW,
+                            None
+                        )]
+                    )
 
-                        if client is None:
-                            client = messaging.connect(redis_address())
-                        
-                        producer.send(
-                            client,
-                            CHANNEL_NAME,
-                            [Message(
-                                bytes(json.dumps({"url": url, "depth": depth + 1}), "utf-8"),
-                                FormatSpec.RAW,
-                                None
-                            )]
-                        )
-
-async def get(url: str) -> Tuple[str, bytes]:
+async def maybe_get(message: Message) -> Optional[Download]:
+    body = json.loads(message.data)
+    url: str = body["url"]
+    depth: int = body["depth"]
+            
+    if depth < MAX_DEPTH:
+        return await get(depth, url)
+    else:
+        return None
+            
+async def get(depth: int, url: str) -> Download:
+    print(f"{datetime.now()}: getting {url}")
+                
     url_parsed = parse.urlparse(url)
 
     match url_parsed.scheme:
@@ -101,10 +123,8 @@ async def get(url: str) -> Tuple[str, bytes]:
     response = await outgoing_request_send(request)
 
     status = http.incoming_response_status(response)
-    if status == 404:
-        return "text/plain", b"not found"
     if status < 200 or status > 299:
-        raise Exception(f"unexpected status for {url}: {status}")
+        return Download(depth, url, "text/plain", bytes(f"unexpected status for {url}: {status}", "utf-8"))
 
     headers = http.fields_entries(http.incoming_response_headers(response))
     content_types = list(map(
@@ -123,28 +143,37 @@ async def get(url: str) -> Tuple[str, bytes]:
         else:
             body.extend(chunk)
 
-    return content_types[0], bytes(body)
+    return Download(depth, url, content_types[0], bytes(body))
 
 class Parser(HTMLParser):
-    def __init__(self, base_url: str = None):
+    def __init__(self, base_url: str):
         HTMLParser.__init__(self)
         self.urls: List[str] = []
         self.base_url = base_url
                         
     def handle_starttag(self, tag: str, attrs: List[Tuple[str, str | None]]):
+        url: Optional[str] = None
         if tag == "a":
             for name, value in attrs:
                 if name == "href" and value is not None:
-                    absurl = parse.urljoin(self.base_url, value)
-                    parsed_url = parse.urlparse(absurl)
+                    url = value
+                    break
+        elif tag == "img":
+            for name, value in attrs:
+                if name == "src" and value is not None:
+                    url = value
+                    break
 
-                    if parsed_url.fragment:
-                        continue
+        if url is None:
+            return
+        
+        absurl = parse.urldefrag(parse.urljoin(self.base_url, url))[0]
+        parsed_url = parse.urlparse(absurl)
 
-                    if absurl.startswith(self.base_url):
-                        self.urls.append(absurl)
+        if absurl.startswith(self.base_url):
+            self.urls.append(absurl)
                         
-def get_urls(html: str, base_url: str = None) -> List[str]:
+def get_urls(html: str, base_url: str) -> List[str]:
     parser = Parser(base_url)
     parser.feed(html)
     return list(set(parser.urls))


### PR DESCRIPTION
We now download URLs concurrently.

Other changes:

- Download `src` URLs found in `img` tags
- Don't ignore URLs with fragments -- just strip the fragments prior to deduplication
- Include timestamps in logs